### PR TITLE
Raise minimal PHP version to 8.3, upgrade endroid/qr-code to v6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .idea
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,12 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "ext-openssl": "*",
         "ext-hash": "*",
         "omnipay/common": "~3.0",
-        "endroid/qr-code": "^5.0"
+        "endroid/qr-code": "^6.0",
+        "symfony/http-client": "^7.4"
     },
     "require-dev": {
         "omnipay/tests": "~4.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,16 +9,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+        </include>
+    </source>
 </phpunit>

--- a/src/Viamo/Message/PurchaseRequest.php
+++ b/src/Viamo/Message/PurchaseRequest.php
@@ -162,8 +162,7 @@ class PurchaseRequest extends AbstractRequest
         $data['vs'] = $this->getVs();
         $data['template'] = 300;
         $data['qr_url'] = $this->getQrEndpoint() . '?text=' . $requestString. '&template=' . $data['template'];
-        $qrCode = new QrCode($requestString);
-        $qrCode->setSize(300);
+        $qrCode = new QrCode(data: $requestString, size: 300);
 
         $writer = new PngWriter();
         $data['qr_data'] = base64_encode($writer->write($qrCode)->getString());

--- a/tests/Viamo/GatewayTest.php
+++ b/tests/Viamo/GatewayTest.php
@@ -19,6 +19,6 @@ class GatewayTest extends GatewayTestCase
 
     public function testPurchase()
     {
-        
+        $this->markTestIncomplete('Not implemented yet.');
     }
 }


### PR DESCRIPTION
Library `endroid/qr-code` was generating PHP 8.4 deprecation notices on v5, upgrade was necessary to cover support for PHP 8.4. The change is minimal, but raise of minimal PHP version will require new major release.

Change was also tested manually and confirmed.